### PR TITLE
Update build.yml for maven&npm cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,6 @@ jobs:
         with:
           node-version: 16
           cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
       - name: Build with Maven
         run: ./mvnw verify


### PR DESCRIPTION
@Ndacyayisenga-droid this updates the build action and introduces npm cache support. By doing so the builds should be faster since not all npm depends need to be downloaded.